### PR TITLE
Fix psql URI format

### DIFF
--- a/lib/pgsync.rb
+++ b/lib/pgsync.rb
@@ -2,6 +2,7 @@ require "pgsync/version"
 require "yaml"
 require "slop"
 require "uri"
+require "uri_postgresql"
 require "erb"
 require "pg"
 require "parallel"
@@ -346,8 +347,10 @@ module PgSync
 
     def parse_uri(url)
       uri = URI.parse(url)
+      uri.scheme ||= 'postgres'
       uri.host ||= "localhost"
       uri.port ||= 5432
+      uri.path = "/#{uri.path}" if uri.path && uri.path[0] != '/'
       uri
     end
 

--- a/lib/uri_postgresql.rb
+++ b/lib/uri_postgresql.rb
@@ -1,0 +1,6 @@
+module URI
+  class POSTGRESQL < Generic
+    DEFAULT_PORT = 5432
+  end
+  @@schemes['POSTGRESQL'] = @@schemes['POSTGRES'] = POSTGRESQL
+end


### PR DESCRIPTION
I add this before when using `schema`

pgsync schema my_table

```
psql: FATAL:  database "//localhost:5432database_dev" does not exist
```

This commit is formatting the uri the right way supported by `psql`

```
postgres://localhost:5432/database_dev
```

