### PR TITLE
Erb parse yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ And in your project directory, run:
 pgsync --setup
 ```
 
-This creates `.pgsync.yml` for you to customize. We recommend checking this into your version control (assuming it doesn’t contain sensitive information). `pgsync` commands can be run from this directory or any subdirectory.
+This creates `.pgsync.yml` for you to customize. We recommend checking this into your version control (assuming it doesn’t contain sensitive information). If you have sensitive information, you can use `ERB` template code in your `.yml` file to output `ENV` variables (For examle `from: <%= ENV['PGSYNC_FROM_SERVER'] %>`).  `pgsync` commands can be run from this directory or any subdirectory.
 
 ## How to Use
 

--- a/lib/pgsync.rb
+++ b/lib/pgsync.rb
@@ -1,4 +1,5 @@
 require "pgsync/version"
+require "erb"
 require "yaml"
 require "slop"
 require "uri"
@@ -331,7 +332,9 @@ Options:}
       @config ||= begin
         if config_file
           begin
-            YAML.load_file(config_file) || {}
+            config_file_content = File.read(config_file)
+            erb_applied         = ERB.new(config_file_content).result(binding)
+            YAML.load(erb_applied) || {}
           rescue Psych::SyntaxError => e
             raise PgSync::Error, e.message
           end


### PR DESCRIPTION
Added functionality to parse the `.yml` files with `ERB` before loading them into `YAML`. We have sensitive variables for the connection options. We rather pass them via shell environment variables.

This way the users can now do something like this:

```
# source database URL
# database URLs take the format of:
#   postgres://user:password@host:port/dbname
# we recommend a command which outputs a database URL
# so sensitive information is not included in this file
from: <%= ENV['PGSYNC_FROM_DATABASE'] %>

# destination database URL
to: <%= ENV['PGSYNC_TO_DATABASE'] %>

# exclude tables
# exclude:
#   - schema_migrations

# define groups
# groups:
#   group1:
#     - table1
#     - table2

# protect sensitive information
data_rules:
  email: unique_email
  phone: unique_phone
  last_name: random_letter
  birthday: random_date
  encrypted_*: null
```

Cheers for the great gem. Really loving it.