### PR TITLE
Fix parsing of psql version

### DIFF
--- a/lib/pgsync.rb
+++ b/lib/pgsync.rb
@@ -98,7 +98,7 @@ module PgSync
         if opts[:schema_only]
           log "* Dumping schema"
           tables = tables.keys.map { |t| "-t #{t}" }.join(" ")
-          psql_version = Gem::Version.new(/\d+\.\d+\.\d+/.match(`psql --version`))
+          psql_version = Gem::Version.new(/(\d+(\.\d+)*(\.|alpha|beta|rc)\d+|\d+\.\d+devel)/.match(`psql --version`))
           if_exists = psql_version >= Gem::Version.new("9.4.0")
           dump_command = "pg_dump -Fc --verbose --schema-only --no-owner --no-acl #{tables} #{to_url(source_uri)}"
           restore_command = "pg_restore --verbose --no-owner --no-acl --clean #{if_exists ? "--if-exists" : nil} -d #{to_url(destination_uri)}"

--- a/lib/pgsync.rb
+++ b/lib/pgsync.rb
@@ -98,7 +98,7 @@ module PgSync
         if opts[:schema_only]
           log "* Dumping schema"
           tables = tables.keys.map { |t| "-t #{t}" }.join(" ")
-          psql_version = Gem::Version.new(/(\d+(\.\d+)*(\.|alpha|beta|rc)\d+|\d+\.\d+devel)/.match(`psql --version`))
+          psql_version = Gem::Version.new(`psql --version`.lines[0].chomp.split(" ")[-1])
           if_exists = psql_version >= Gem::Version.new("9.4.0")
           dump_command = "pg_dump -Fc --verbose --schema-only --no-owner --no-acl #{tables} #{to_url(source_uri)}"
           restore_command = "pg_restore --verbose --no-owner --no-acl --clean #{if_exists ? "--if-exists" : nil} -d #{to_url(destination_uri)}"

--- a/lib/pgsync.rb
+++ b/lib/pgsync.rb
@@ -98,7 +98,7 @@ module PgSync
         if opts[:schema_only]
           log "* Dumping schema"
           tables = tables.keys.map { |t| "-t #{t}" }.join(" ")
-          psql_version = Gem::Version.new(`psql --version`.split(" ").last)
+          psql_version = Gem::Version.new(/\d+\.\d+\.\d+/.match(`psql --version`))
           if_exists = psql_version >= Gem::Version.new("9.4.0")
           dump_command = "pg_dump -Fc --verbose --schema-only --no-owner --no-acl #{tables} #{to_url(source_uri)}"
           restore_command = "pg_restore --verbose --no-owner --no-acl --clean #{if_exists ? "--if-exists" : nil} -d #{to_url(destination_uri)}"


### PR DESCRIPTION
When I try running pgsync I get the following error:

>/home/vagrant/.rbenv/versions/2.2.5/lib/ruby/2.2.0/rubygems/version.rb:206:in 'initialize': Malformed version number string editing (ArgumentError)
        from /home/vagrant/.rbenv/versions/2.2.5/lib/ruby/2.2.0/rubygems/version.rb:198:in 'new'
        from /home/vagrant/.rbenv/versions/2.2.5/lib/ruby/2.2.0/rubygems/version.rb:198:in 'new'
        from /home/vagrant/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/pgsync-0.3.6/lib/pgsync.rb:101:in 'perform'
        from /home/vagrant/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/pgsync-0.3.6/exe/pgsync:5:in '\<top (required)\>'
        from /home/vagrant/.rbenv/versions/2.2.5/bin/pgsync:23:in 'load'
        from /home/vagrant/.rbenv/versions/2.2.5/bin/pgsync:23:in '\<main\>'

In my case, my installation of postgresql outputs this when I run `psql --version`:

> (PostgreSQL) 9.0.23
> contains support for command-line editing

In [this line](https://github.com/ankane/pgsync/blob/master/lib/pgsync.rb#L101) we have 
``psql_version = Gem::Version.new(`psql --version`.split(" ").last)``
which, in my case, tries to parse a version string out of the word "editing".

Instead of splitting on whitespace and assuming the version string is the last element, we should extract the version using a regex.