### PR TITLE
Use double quotes to pass raw id parameter

### DIFF
--- a/lib/pgsync.rb
+++ b/lib/pgsync.rb
@@ -492,7 +492,9 @@ Options:}
       if value.is_a?(Array)
         value
       else
-        value.to_s.split(",")
+        # Split by commas, but don't use commas inside double quotes
+        # http://stackoverflow.com/questions/21105360/regex-find-comma-not-inside-quotes
+        value.to_s.split(/(?!\B"[^"]*),(?![^"]*"\B)/)
       end
     end
 
@@ -651,7 +653,7 @@ Options:}
     end
 
     def cast(value)
-      value.to_s
+      value.to_s.gsub(/\A\"|\"\z/, '')
     end
 
     def deprecated(message)


### PR DESCRIPTION
As discussed here https://github.com/ankane/pgsync/issues/8 we can't pass multiple ids pgsync
So I've made small changes, that allows escaping of such kind of values with double quotes

```
pgsync product:\"(1,2,3)\"

groups:
  product:
    products: "where id IN {1}"
    reviews: "where product_id IN {1}"
    coupons: "where product_id IN {1} order by created_at desc limit 10"
    stores: "where id in (select store_id from products where id IN {1})"

```