### PR TITLE
Parse YAML config file as ERB

### DIFF
--- a/lib/pgsync.rb
+++ b/lib/pgsync.rb
@@ -337,7 +337,8 @@ Options:}
       @config ||= begin
         if config_file
           begin
-            YAML.load_file(config_file) || {}
+            template = ERB.new(File.read(config_file))
+            YAML.load(template.result) || {}
           rescue Psych::SyntaxError => e
             raise PgSync::Error, e.message
           end


### PR DESCRIPTION
Allows using environment variables in pgsync YAML config files, similar to rails' secrets and database configs.

Looks like this might've been intended from the beginning but may have gotten lost along the way, based on the already present `require 'erb'`.