### PR TITLE
Allow passing full path to config option

### DIFF
--- a/lib/pgsync/utils.rb
+++ b/lib/pgsync/utils.rb
@@ -31,6 +31,8 @@ module PgSync
     end
 
     def search_tree(file)
+      return file if File.exists?(file)
+
       path = Dir.pwd
       # prevent infinite loop
       20.times do


### PR DESCRIPTION
Hello!

I'm setting up pgsync for an internal project where we automatically generate the configuration files in a temporary file. Passing the file to the `--config` wasn't working when providing the full path.