### PR TITLE
Raise error if destination and source are the same

### DIFF
--- a/lib/pgsync/sync.rb
+++ b/lib/pgsync/sync.rb
@@ -37,6 +37,8 @@ module PgSync
       print_description("From", source)
       print_description("To", destination)
 
+      raise Error, "Destination must be different from source" if source.url == destination.url
+
       if (opts[:preserve] || opts[:overwrite]) && destination.server_version_num < 90500
         raise Error, "Postgres 9.5+ is required for --preserve and --overwrite"
       end

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -63,6 +63,10 @@ class SyncTest < Minitest::Test
     assert_error "No primary key", "chapters --preserve", config: true
   end
 
+  def test_same_source_destination
+    assert_error "Destination must be different from source", "--from pgsync_test1 --to pgsync_test1", config: true
+  end
+
   def test_no_shared_fields
     assert_prints "authors: No fields to copy", "authors", config: true
   end


### PR DESCRIPTION
This makes no sense and might actually do something unintended if done by accident, e.g. truncating the source if run with `--truncate`.