### PR TITLE
Ignore generated columns in INSERT

### DIFF
--- a/lib/pgsync/task.rb
+++ b/lib/pgsync/task.rb
@@ -142,7 +142,7 @@ module PgSync
             setter = shared_fields.reject { |f| primary_key.include?(f) }.map { |f| "#{quote_ident(f)} = EXCLUDED.#{quote_ident(f)}" }
             "UPDATE SET #{setter.join(", ")}"
           end
-        destination.execute("INSERT INTO #{quoted_table} (SELECT * FROM #{quote_ident_full(temp_table)}) ON CONFLICT (#{on_conflict}) DO #{action}")
+        destination.execute("INSERT INTO #{quoted_table} (#{fields}) (SELECT #{fields} FROM #{quote_ident_full(temp_table)}) ON CONFLICT (#{on_conflict}) DO #{action}")
       else
         # use delete instead of truncate for foreign keys
         if opts[:defer_constraints] || opts[:defer_constraints_v2]


### PR DESCRIPTION
This is a complementary fix for #108.

As the generated columns exist on the destination table, they were copied during the [`CREATE TEMPORARY TABLE ... AS TABLE ...`](https://github.com/ankane/pgsync/blob/4aea31b3bdfb937cad718efcfb5e88d5181d73e0/lib/pgsync/task.rb#L132), so when executing the [`INSERT INTO ... (SELECT *) ON CONFLICT ...`](https://github.com/ankane/pgsync/blob/4aea31b3bdfb937cad718efcfb5e88d5181d73e0/lib/pgsync/task.rb#L145), it tries to insert them which, of course, will fail even if they're not listed in the `ON CONFLICT` fields.

This is fixed by explicitly listing the field we want to insert.