### PR TITLE
 Allow ERB in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.0
+
+Breaking
+
+- Allow erb templating in config. Please escape if you used erb specials in config before.
+
 ## 0.6.7 (2021-04-26)
 
 - Fixed connection security for `--schema-first` and `--schema-only` - [more info](https://github.com/ankane/pgsync/issues/121)

--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@
 from: $(some_command)?sslmode=require
 
 # destination database URL
-to: postgres://localhost:5432/myapp_development
+to: postgres://localhost:5432/<%%= ENV.fetch('PGSYNC_TARGET_DB_NAME', 'myapp_development') %%>
 
 # exclude tables
 %{exclude}

--- a/lib/pgsync/sync.rb
+++ b/lib/pgsync/sync.rb
@@ -78,7 +78,8 @@ module PgSync
         file = config_file
         if file
           begin
-            YAML.load_file(file) || {}
+            require 'erb'
+            YAML.load(ERB.new(File.read(file)).result) || {}
           rescue Psych::SyntaxError => e
             raise Error, e.message
           rescue Errno::ENOENT

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,0 +1,32 @@
+require_relative "test_helper"
+
+class ConfigTest < Minitest::Test
+    def test_process_erb
+        with_temp_file(<<~EOF
+            from: "pgsync_test1"
+            to: <%= 'pgsync_test2' %>
+        EOF
+        ) do |path|
+            assert_works "--config #{path}"
+        end
+    end
+
+    def test_process_shell_command_in_config
+        with_temp_file(<<~EOF
+            from: "pgsync_test1"
+            to: $(echo 'pgsync_test2')
+        EOF
+        ) do |path|
+            assert_works "--config #{path}"
+        end
+    end
+
+    def with_temp_file(content = '', &block)
+        file = Tempfile.new('config')
+        file.write(content)
+        file.close
+        block.call(file.path)
+    ensure
+        file.unlink
+    end
+end


### PR DESCRIPTION
Added option to use erb syntax in config file.
This allows to add interpolations in various places. 
For example to use env variable or ruby code as a value when replacing sensitive information. Each developer can replace user emails with own email using the same config file.

This also can be used to replace custom shell command execution for `from:` and `to:` values.