### PR TITLE
Add option to skip duplicate upserts.

### DIFF
--- a/lib/pgsync/client.rb
+++ b/lib/pgsync/client.rb
@@ -56,6 +56,7 @@ module PgSync
       o.boolean "--overwrite", "overwrite existing rows", default: false
       o.boolean "--preserve", "preserve existing rows", default: false
       o.boolean "--truncate", "truncate existing rows", default: false
+      o.boolean "--overwrite-only-changed", "Only overwrite rows with values that have changed", default: false
 
       o.separator ""
       o.separator "Foreign key options:"

--- a/lib/pgsync/task.rb
+++ b/lib/pgsync/task.rb
@@ -140,8 +140,13 @@ module PgSync
             "NOTHING"
           else # overwrite or sql clause
             setter = shared_fields.reject { |f| primary_key.include?(f) }.map { |f| "#{quote_ident(f)} = EXCLUDED.#{quote_ident(f)}" }
+            if opts[:overwrite_only_changed]
+              nooper = "WHERE NOT (#{shared_fields.reject { |f| primary_key.include?(f) }.map { |f| "#{quoted_table}.#{quote_ident(f)} = EXCLUDED.#{quote_ident(f)}" }.join(" AND ")})"
+            else
+              nooper = ""
+            end
             if setter.any?
-              "UPDATE SET #{setter.join(", ")}"
+              "UPDATE SET #{setter.join(", ")} #{nooper}"
             else
               "NOTHING"
             end


### PR DESCRIPTION
When using the overwrite mode, pgsync does a blind upsert which ends up creating duplicate/new row versions for ALL rows involved in the sync regardless of whether or not any of the values in those rows have changed. 

This is largely fine/functionally correct, but it's not ideal as it places additional write/transaction load on the receiving database which isn't strictly needed.

It might make sense to just make this behavior the default, but I haven't fully thought that through. 

Any thoughts on the idea? 