### PR TITLE
Allow aliases in YAML with Ruby 3.1

### DIFF
--- a/lib/pgsync/sync.rb
+++ b/lib/pgsync/sync.rb
@@ -78,7 +78,7 @@ module PgSync
         file = config_file
         if file
           begin
-            YAML.load_file(file) || {}
+            YAML.safe_load_file(file, aliases: true) || {}
           rescue Psych::SyntaxError => e
             raise Error, e.message
           rescue Errno::ENOENT


### PR DESCRIPTION
Ruby 3.1 uses Psych 4 by default, which won't ingest YAML aliases by
default. This results in pgsync configuration files that contain YAML
aliases failing with an error about undefined aliases, even if the
tables or groups used don't require those aliases.

This change updates the YAML loading to use `YAML.safe_load_file` and to
specify `aliases: true`. This is compatible with Ruby 3.1 / Psych 4's
defaults, but should be backward compatible with earlier versions (I
tested with Ruby 3.0.3 as well and it worked without issue.)