### PR TITLE
Add shell option in data rules

### DIFF
--- a/lib/pgsync/sync.rb
+++ b/lib/pgsync/sync.rb
@@ -148,22 +148,6 @@ module PgSync
       ds
     end
 
-    # ideally aliases would work, but haven't found a nice way to do this
-    def resolve_source(source)
-      if source
-        source = source.dup
-        source.gsub!(/\$\([^)]+\)/) do |m|
-          command = m[2..-2]
-          result = `#{command}`.chomp
-          unless $?.success?
-            raise Error, "Command exited with non-zero status:\n#{command}"
-          end
-          result
-        end
-      end
-      source
-    end
-
     def self.finalize(ds)
       # must use proc instead of stabby lambda
       proc { ds.close }

--- a/lib/pgsync/task.rb
+++ b/lib/pgsync/task.rb
@@ -236,7 +236,7 @@ module PgSync
           escape(rule["value"])
         elsif rule.key?("statement")
           rule["statement"]
-        elsif rule.key("shell")
+        elsif rule.key?("shell")
           resolve_source(rule["shell"])
         else
           raise Error, "Unknown rule #{rule.inspect} for column #{column}"

--- a/lib/pgsync/task.rb
+++ b/lib/pgsync/task.rb
@@ -236,6 +236,8 @@ module PgSync
           escape(rule["value"])
         elsif rule.key?("statement")
           rule["statement"]
+        elsif rule.key("shell")
+          resolve_source(rule["shell"])
         else
           raise Error, "Unknown rule #{rule.inspect} for column #{column}"
         end

--- a/lib/pgsync/utils.rb
+++ b/lib/pgsync/utils.rb
@@ -83,5 +83,21 @@ module PgSync
     def quote_string(s)
       s.gsub(/\\/, '\&\&').gsub(/'/, "''")
     end
+
+    # ideally aliases would work, but haven't found a nice way to do this
+    def resolve_source(source)
+      if source
+        source = source.dup
+        source.gsub!(/\$\([^)]+\)/) do |m|
+          command = m[2..-2]
+          result = `#{command}`.chomp
+          unless $?.success?
+            raise Error, "Command exited with non-zero status:\n#{command}"
+          end
+          result
+        end
+      end
+      source
+    end
   end
 end

--- a/test/data_rules_test.rb
+++ b/test/data_rules_test.rb
@@ -29,6 +29,7 @@ class DataRulesTest < Minitest::Test
     assert row["ip"].end_with?("0.0.1")
     assert_equal 1, row["name"].size
     assert_equal "rock", row["untouchable"]
+    assert_equal "shell", row["nonsense"]
   end
 
   def test_no_rules

--- a/test/support/config.yml
+++ b/test/support/config.yml
@@ -21,5 +21,5 @@ data_rules:
   updated_at: random_time
   public.Users.ip: random_ip
   Users.name: random_letter
-  nonsense:
+  Users.nonsense:
     shell: $(echo "'shell'")

--- a/test/support/config.yml
+++ b/test/support/config.yml
@@ -21,4 +21,5 @@ data_rules:
   updated_at: random_time
   public.Users.ip: random_ip
   Users.name: random_letter
-  nonsense: random_string
+  nonsense:
+    shell: $(echo "'shell'")


### PR DESCRIPTION
## Hey @ankane, regards from TH inc.

The idea of this PR is to add a new option in the `data-rules` step enabling shell execution. The main motivation is because sometimes we have sensitive data in the remote database and we want to override that using variables from the local environment.

