### PR TITLE
Fix the size of alphabet on random_letter function

### DIFF
--- a/lib/pgsync/task.rb
+++ b/lib/pgsync/task.rb
@@ -258,7 +258,7 @@ module PgSync
         when "random_ip"
           "(1 + RANDOM() * 254)::int::text || '.0.0.1'"
         when "random_letter"
-          "chr(65 + (RANDOM() * 26)::int)"
+          "chr(65 + (RANDOM() * 25)::int)"
         when "random_string"
           "RIGHT(MD5(RANDOM()::text), 10)"
         when "null", nil


### PR DESCRIPTION
Hello! :hand: 

This PR fixes a small issue when generating a random card.

The ASCII letters go from `65 | A` to `90 | Z`.
The way we were accidentally doing this might throw a `91 | [`, which is rejected by most text validators