### PR TITLE
Update Slop dependency

### DIFF
--- a/pgsync.gemspec
+++ b/pgsync.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "parallel"
   spec.add_dependency "pg", ">= 0.18.2"
-  spec.add_dependency "slop", ">= 4.8.2"
+  spec.add_dependency "slop", ">= 4.10.1"
   spec.add_dependency "tty-spinner"
 end


### PR DESCRIPTION
Hi, 
Thanks for the pgsync work.
A regression seems to occur in the slop dependency.

The use of the command line options `--to-safe` seems to not work with some version of Slop.

The commit who introduced the bug, I think : https://github.com/leejarvis/slop/commit/a23fa41a5674485600365985bea2a905e5e087df
And the one who solved it : https://github.com/leejarvis/slop/commit/de796008bba708263b5cf093b48af7a6ebeb1d1a

Can we upgrade the slop dependency so ?

Hope it's help ;)
Have a nice day