### PR TITLE
Replication origin support

### DIFF
--- a/lib/pgsync/client.rb
+++ b/lib/pgsync/client.rb
@@ -101,6 +101,7 @@ module PgSync
       o.boolean "--in-batches", "sync in batches", default: false, help: false
       o.integer "--batch-size", "batch size", default: 10000, help: false
       o.float "--sleep", "time to sleep between batches", default: 0, help: false
+      o.string "--replication-origin", "replication origin", help: false
 
       o.separator ""
       o.separator "Other commands:"

--- a/lib/pgsync/data_source.rb
+++ b/lib/pgsync/data_source.rb
@@ -106,15 +106,8 @@ module PgSync
           CASE
             WHEN EXISTS (SELECT 1 FROM pg_replication_origin WHERE roname = $1) THEN null
             ELSE pg_replication_origin_create($1)
-          END;
-      SQL
-      execute(query, [origin])
-      query = <<~SQL
-        SELECT
-          CASE
-            WHEN pg_replication_origin_session_is_setup() THEN null
-            ELSE pg_replication_origin_session_setup($1)
-          END;
+          END,
+          pg_replication_origin_session_setup($1);
       SQL
       execute(query, [origin])
     end

--- a/lib/pgsync/sync.rb
+++ b/lib/pgsync/sync.rb
@@ -19,7 +19,7 @@ module PgSync
       end
 
       # merge other config
-      [:to_safe, :exclude, :schemas].each do |opt|
+      [:to_safe, :exclude, :schemas, :replication_origin].each do |opt|
         opts[opt] ||= config[opt.to_s]
       end
 

--- a/lib/pgsync/table_sync.rb
+++ b/lib/pgsync/table_sync.rb
@@ -248,7 +248,9 @@ module PgSync
         Parallel.each(tasks, **options) do |task|
           source.reconnect_if_needed
           destination.reconnect_if_needed
-
+          if opts[:replication_origin]
+            destination.set_replication_origin(opts[:replication_origin])
+          end
           task.perform
         end
       end

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -178,7 +178,6 @@ class SyncTest < Minitest::Test
 
   def test_replication_origin
     insert(conn1, "posts", [{"id" => 1}])
-    assert_error "Sync failed for 1 table: posts", "posts", config: true
     assert_works "posts --replication-origin=test --debug", config: true
     assert_equal [{"exists" => 1}], conn2.exec("SELECT 1 AS exists FROM pg_replication_origin WHERE roname = 'test'").to_a
   end

--- a/test/sync_test.rb
+++ b/test/sync_test.rb
@@ -175,4 +175,11 @@ class SyncTest < Minitest::Test
     assert_equal [], conn2.exec("SELECT * FROM posts ORDER BY id").to_a
     assert_equal [{"post_id" => 1}], conn2.exec("SELECT post_id FROM comments ORDER BY post_id").to_a
   end
+
+  def test_replication_origin
+    insert(conn1, "posts", [{"id" => 1}])
+    assert_error "Sync failed for 1 table: posts", "posts", config: true
+    assert_works "posts --replication-origin=test --debug", config: true
+    assert_equal [{"exists" => 1}], conn2.exec("SELECT 1 AS exists FROM pg_replication_origin WHERE roname = 'test'").to_a
+  end
 end


### PR DESCRIPTION
purpose of this PR is to add support for `--replication-origin=foo` that defines the replication origin setting to target database. This allows other sync/replication mechanisms to understand when data comes from pgsync and allows DBAs to configure setups for example to prevent triggering a cascade effect when pgsync is used with databases that have replication setup.