### PR TITLE
fix: Make Cascade Conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1 (TBD)
+
+- Support truncation without cascade when `--disable-integrity` is specified - [more info](https://github.com/ankane/pgsync/issues/125)
+
 ## 0.8.0 (2024-07-10)
 
 - Added Docker image for `linux/arm64`

--- a/lib/pgsync/data_source.rb
+++ b/lib/pgsync/data_source.rb
@@ -64,8 +64,12 @@ module PgSync
       execute("SELECT last_value FROM #{quote_ident_full(seq)}").first["last_value"]
     end
 
-    def truncate(table)
+    def truncate_with_cascade(table)
       execute("TRUNCATE #{quote_ident_full(table)} CASCADE")
+    end
+
+    def truncate(table)
+      execute("TRUNCATE #{quote_ident_full(table)}")
     end
 
     def schemas


### PR DESCRIPTION
I ran into a similar issue reported in #125 when running:

```sh
pgsync --jobs 1 --disable-integrity --no-sequences --disable-user-triggers --debug --from postgresql://$(FROM_USER):$(FROM_PASSWORD)@$(FROM_HOST):$(FROM_PORT)/$(FROM_DATABASE)?sslmode=require --to postgresql://$(TO_USER):$(TO_PASSWORD)@$(TO_HOST):$(TO_PORT)/$(TO_DATABASE)?sslmode=require --to-safe
```

Using AWS RDS, performance insights shows long locks associated with foreign keys and 2-3 hours to sync a mid-size database when the cascade is across tables already synced.

I believe there is more nuance here and this change doesn't capture the cases where CASCADE should be used or not, so I'm going to try keeping CASCADE with 0.8.0 and manually ordering the tables.

Although, I might be doing something wrong or there is a better way to leverage pgsync more efficiently.